### PR TITLE
Escaped unicode for sylabus_txt

### DIFF
--- a/course_utils.py
+++ b/course_utils.py
@@ -105,6 +105,7 @@ def getSylabus(className, username, password):
             cookies_class = loadSavedClassCookies(username)
             cookies_class[className] = cookies.get_dict()
 
+    sylabus_txt = sylabus_txt.decode('unicode_escape').encode('ascii','ignore')
     parsed = parse_syllabus(sylabus_txt)
 
     return parsed


### PR DESCRIPTION
I added this patch on my own xbmc to fix an error parsing unicode characters in the syllabus text of the course 'Introduction to Classical Music'.

My git skills are limited and this is my first pull request, so please forgive me if I've done it wrong. If so, feel free to just review the change and add it (or something similar) to your own code.